### PR TITLE
move logic to store controller_helper

### DIFF
--- a/lib/spree/core/controller_helpers/store_decorator.rb
+++ b/lib/spree/core/controller_helpers/store_decorator.rb
@@ -1,0 +1,10 @@
+Spree::Core::ControllerHelpers::Store.module_eval do
+  # This method was moved from order helper
+  def current_currency
+    if session.key?(:currency) && supported_currencies.map(&:iso_code).include?(session[:currency])
+      session[:currency]
+    else
+      Spree::Config[:currency]
+    end
+  end
+end


### PR DESCRIPTION
current_currency must be decorated on store controller_helper instead order controller_helper https://github.com/spree/spree/blob/master/core/lib/spree/core/controller_helpers/store.rb#L13